### PR TITLE
Remove ambiguous warning

### DIFF
--- a/lib/conqueuer/util.ex
+++ b/lib/conqueuer/util.ex
@@ -54,7 +54,7 @@ defmodule Conqueuer.Util do
   def ip_to_binary( ip_tuple ) do
     ip_tuple
     |> Tuple.to_list
-    |> Enum.join "."
+    |> Enum.join( "." )
   end
 
   def ip_to_tuple( ip_str ) do


### PR DESCRIPTION
lib/conqueuer/util.ex:57: warning: you are piping into a function call without parentheses, which may be ambiguous. Please wrap the function you are piping into in parentheses. For example:

```
foo 1 |> bar 2 |> baz 3
```

Should be written as:

```
foo(1) |> bar(2) |> baz(3)
```
