### PR TITLE
Optional queue limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Conqueuer can be installed like:
         def application do
           [applications: [:conqueuer]]
         end
+
+### Testing
+
+`mix espec`

--- a/lib/conqueuer.ex
+++ b/lib/conqueuer.ex
@@ -95,8 +95,10 @@ defmodule Conqueuer do
   def work( name, args \\ nil ) do
     {foreman_name, queue_name} = Util.infer_conqueuer_collaborator_names(name)
 
-    Conqueuer.Queue.enqueue(queue_name, args)
-    Conqueuer.Foreman.work_arrived(foreman_name)
+    case Conqueuer.Queue.enqueue(queue_name, args) do
+      {:ok} -> Conqueuer.Foreman.work_arrived(foreman_name)
+      res -> res
+    end
   end
 
   @doc """

--- a/lib/conqueuer.ex
+++ b/lib/conqueuer.ex
@@ -96,7 +96,7 @@ defmodule Conqueuer do
     {foreman_name, queue_name} = Util.infer_conqueuer_collaborator_names(name)
 
     case Conqueuer.Queue.enqueue(queue_name, args) do
-      {:ok} -> Conqueuer.Foreman.work_arrived(foreman_name)
+      :ok -> Conqueuer.Foreman.work_arrived(foreman_name)
       res -> res
     end
   end

--- a/lib/conqueuer.ex
+++ b/lib/conqueuer.ex
@@ -149,7 +149,7 @@ defmodule Conqueuer do
       opts = [strategy: :one_for_one, name: MyApp.Supervisor]
       Supervisor.start_link(children, opts)
   """
-  def child_specs(pool_name, pool_supervisor_module, opts \\ []) do
+  def child_specs(pool_name, pool_supervisor_module, _opts) do
     import Supervisor.Spec, warn: false
 
     {foreman, pool, pool_supervisor, queue} = Util.infer_collaborator_names(pool_name)

--- a/lib/conqueuer/foreman.ex
+++ b/lib/conqueuer/foreman.ex
@@ -71,8 +71,6 @@ defmodule Conqueuer.Foreman do
   end
 
   def handle_cast( :work_arrived, state ) do
-    #debug "work arrived"
-
     %{pool_name: pool,
       queue_name: queue} = state
 
@@ -82,13 +80,10 @@ defmodule Conqueuer.Foreman do
   end
 
   def handle_cast( {:finished, worker}, state ) do
-    #debug "work finished, checking worker in"
-
     %{pool_name: pool,
       queue_name: queue} = state
 
     :poolboy.checkin( pool, worker )
-    #debug "Poolboy status: #{inspect :poolboy.status( pool )}"
 
     drain_queue pool, queue
 
@@ -98,7 +93,6 @@ defmodule Conqueuer.Foreman do
   # Private ##########
 
   defp drain_queue( pool, queue ) do
-    #debug "draining queue"
 
     case :poolboy.status( pool ) do
       {:ready, _, _, _} ->
@@ -108,7 +102,6 @@ defmodule Conqueuer.Foreman do
         do_work pool, queue
 
       {:full, _, _, _} ->
-        #warn "pool exhausted, stopping drain"
         :exhausted
     end
   end
@@ -121,7 +114,6 @@ defmodule Conqueuer.Foreman do
         drain_queue pool, queue
 
       :empty ->
-        #debug "queue empty, stopping drain"
         :empty
     end
   end
@@ -129,10 +121,5 @@ defmodule Conqueuer.Foreman do
   defp queue_next( queue ) do
     Conqueuer.Queue.next queue
   end
-
-  defp debug( msg ), do: Logger.debug "#{log_label} #{msg}"
-  defp warn( msg ),  do: Logger.warn "#{log_label} #{msg}"
-
-  defp log_label, do: "[#{Util.registered_name self}]"
 
 end

--- a/lib/conqueuer/foreman.ex
+++ b/lib/conqueuer/foreman.ex
@@ -110,7 +110,7 @@ defmodule Conqueuer.Foreman do
     case queue_next( queue ) do
       {:ok, args} ->
         worker = :poolboy.checkout( pool )
-        GenServer.cast worker, {:work, self, args}
+        GenServer.cast worker, {:work, self(), args}
         drain_queue pool, queue
 
       :empty ->

--- a/lib/conqueuer/pool.ex
+++ b/lib/conqueuer/pool.ex
@@ -57,14 +57,14 @@ defmodule Conqueuer.Pool do
 
       def init([]) do
         pool_options = [
-          name: {:local, name},
-          worker_module: worker,
-          size: size,
-          max_overflow: max_overflow
+          name: {:local, name()},
+          worker_module: worker(),
+          size: size(),
+          max_overflow: max_overflow()
         ]
 
         children = [
-          :poolboy.child_spec(name, pool_options, worker_args)
+          :poolboy.child_spec(name(), pool_options, worker_args())
         ]
 
         supervise(children, strategy: :one_for_one)

--- a/lib/conqueuer/queue.ex
+++ b/lib/conqueuer/queue.ex
@@ -6,6 +6,14 @@ defmodule Conqueuer.Queue do
 
   # Public API ############
 
+  @doc """
+  Starts a `Conqueuer.Queue` process.
+
+  ## Optional Args
+  
+    * `:limit` - if present, the queue will limit the number of items that are allowed to be enqueued
+      into memory.
+  """
   def start_link(args \\ [], opts \\ []) do
     GenServer.start_link __MODULE__, args, opts
   end

--- a/lib/conqueuer/queue.ex
+++ b/lib/conqueuer/queue.ex
@@ -18,30 +18,48 @@ defmodule Conqueuer.Queue do
     GenServer.start_link __MODULE__, args, opts
   end
 
+  @doc """
+  Empties out the queue
+  """
   def empty( queue ) do
     GenServer.cast queue, :empty
   end
 
+  @doc """
+  """
   def enqueue( queue , item) do
     GenServer.call queue, {:enqueue, item}
   end
 
+  @doc """
+  """
   def member?( queue , item) do
     GenServer.call queue, {:member?, item}
   end
 
+  @doc """
+  """
   def next( queue ) do
     GenServer.call queue, :next
   end
 
+  @doc """
+  Returns the current queue size.
+  """
   def size( queue ) do
     GenServer.call queue, :size
   end
 
+  @doc """
+  Returns the configured queue limit, if applied.
+  """
   def limit( queue ) do
     GenServer.call queue, :limit
   end
 
+  @doc """
+  Checks the queue to see if the size limit was reached.
+  """
   def limit_reached?( queue ) do
     GenServer.call queue, :limit_reached?
   end

--- a/lib/conqueuer/util.ex
+++ b/lib/conqueuer/util.ex
@@ -54,7 +54,7 @@ defmodule Conqueuer.Util do
   def ip_to_binary( ip_tuple ) do
     ip_tuple
     |> Tuple.to_list
-    |> Enum.join "."
+    |> Enum.join(".")
   end
 
   def ip_to_tuple( ip_str ) do

--- a/lib/conqueuer/util.ex
+++ b/lib/conqueuer/util.ex
@@ -64,8 +64,4 @@ defmodule Conqueuer.Util do
     |> List.to_tuple
   end
 
-  def registered_name( pid ) do
-    Process.info( self )[:registered_name]
-  end
-
 end

--- a/lib/conqueuer/util.ex
+++ b/lib/conqueuer/util.ex
@@ -44,7 +44,7 @@ defmodule Conqueuer.Util do
   # TODO move to external project
 
   def pid_as_string do
-    pid_to_string self
+    pid_to_string self()
   end
 
   def pid_to_string( pid ) do

--- a/lib/conqueuer/worker.ex
+++ b/lib/conqueuer/worker.ex
@@ -48,7 +48,7 @@ defmodule Conqueuer.Worker do
           perform args, state
         end
 
-        Conqueuer.Foreman.finished foreman, self
+        Conqueuer.Foreman.finished foreman, self()
 
         {:noreply, state}
       end

--- a/mix.exs
+++ b/mix.exs
@@ -4,12 +4,12 @@ defmodule Conqueuer.Mixfile do
   def project do
     [app: :conqueuer,
      version: "0.5.1",
-     elixir: "~> 1.1",
+     elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      preferred_cli_env: [espec: :test],
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package]
+     deps: deps(),
+     package: package()]
   end
 
   defp package do
@@ -33,7 +33,7 @@ defmodule Conqueuer.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   # Dependencies can be Hex packages:
@@ -47,8 +47,8 @@ defmodule Conqueuer.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:espec, "~> 1.1.1", only: :test},
-      {:ex_doc, "~> 0.14.3", only: :dev},
+      {:espec, "~> 1.2.1", only: :test},
+      {:ex_doc, "~> 0.14.5", only: :dev},
       {:earmark, ">= 1.0.3", only: :dev},
       {:inflex, "~> 1.8.0"},
       {:poolboy, "~> 1.5.1"}

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Conqueuer.Mixfile do
 
   def project do
     [app: :conqueuer,
-     version: "0.5.2",
+     version: "0.5.1",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      preferred_cli_env: [espec: :test],

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Conqueuer.Mixfile do
 
   def project do
     [app: :conqueuer,
-     version: "0.5.1",
+     version: "0.5.2",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      preferred_cli_env: [espec: :test],
@@ -47,11 +47,11 @@ defmodule Conqueuer.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:espec, "~> 0.8", only: :test},
-      {:ex_doc, "~> 0.10", only: :dev},
-      {:earmark, ">= 0.0.0", only: :dev},
-      {:inflex, "~> 1.5"},
-      {:poolboy, "~> 1.5"}
+      {:espec, "~> 1.1.1", only: :test},
+      {:ex_doc, "~> 0.14.3", only: :dev},
+      {:earmark, ">= 1.0.3", only: :dev},
+      {:inflex, "~> 1.8.0"},
+      {:poolboy, "~> 1.5.1"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Conqueuer.Mixfile do
     [
       {:espec, "~> 0.8", only: :test},
       {:ex_doc, "~> 0.10", only: :dev},
-        {:earmark, ">= 0.0.0", only: :dev},
+      {:earmark, ">= 0.0.0", only: :dev},
       {:inflex, "~> 1.5"},
       {:poolboy, "~> 1.5"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Conqueuer.Mixfile do
 
   def project do
     [app: :conqueuer,
-     version: "0.5.1",
+     version: "0.5.2",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      preferred_cli_env: [espec: :test],
@@ -47,10 +47,10 @@ defmodule Conqueuer.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:espec, "~> 1.2.1", only: :test},
-      {:ex_doc, "~> 0.14.5", only: :dev},
-      {:earmark, ">= 1.0.3", only: :dev},
-      {:inflex, "~> 1.8.0"},
+      {:espec, "~> 1.4.5", only: :test},
+      {:ex_doc, "~> 0.16.2", only: :dev},
+      {:earmark, ">= 1.2.3", only: :dev},
+      {:inflex, "~> 1.8.1"},
       {:poolboy, "~> 1.5.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "espec": {:hex, :espec, "1.2.1", "faf0b54502688401097d8cb36da3f9ba75f894a39bccc65e5ae7bffb1256f03e", [:mix], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "inflex": {:hex, :inflex, "1.8.0", "7cfc752ae244b30b42ac9cf4c092771b485bc3424139aba4a933e54be8c63931", [:mix], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
+%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
+  "espec": {:hex, :espec, "1.4.5", "42defe77dadd02c011281a1ee22c5e468303d2806c024e9ee9be6d18171d771f", [], [{:meck, "0.8.7", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "inflex": {:hex, :inflex, "1.8.1", "9fa9684ff1a872eab7415c0be500cc1b7782f28da6ed75423081e75f92831b1c", [], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.7", "ebad16ca23f685b07aed3bc011efff65fbaf28881a8adf925428ef5472d390ee", [], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"earmark": {:hex, :earmark, "0.1.19"},
-  "espec": {:hex, :espec, "0.8.1"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "inflex": {:hex, :inflex, "1.5.0"},
-  "meck": {:hex, :meck, "0.8.3"},
-  "poolboy": {:hex, :poolboy, "1.5.1"}}
+%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "espec": {:hex, :espec, "0.8.28", "f002710673d215876c4ca6fc74cbf5e330954badea7389d2284d2050940f1779", [:mix], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "inflex": {:hex, :inflex, "1.7.0", "4466a34b7d8e871d8164619ba0f3b8410ec782e900f0ae1d3d27a5875a29532e", [:mix], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "espec": {:hex, :espec, "0.8.28", "f002710673d215876c4ca6fc74cbf5e330954badea7389d2284d2050940f1779", [:mix], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "inflex": {:hex, :inflex, "1.7.0", "4466a34b7d8e871d8164619ba0f3b8410ec782e900f0ae1d3d27a5875a29532e", [:mix], []},
+%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+  "espec": {:hex, :espec, "1.1.1", "ed3b3ec3e909183841245a4649fe31d80a101e93cbff473f156715f3f0946625", [:mix], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "inflex": {:hex, :inflex, "1.8.0", "7cfc752ae244b30b42ac9cf4c092771b485bc3424139aba4a933e54be8c63931", [:mix], []},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "espec": {:hex, :espec, "1.1.1", "ed3b3ec3e909183841245a4649fe31d80a101e93cbff473f156715f3f0946625", [:mix], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "espec": {:hex, :espec, "1.2.1", "faf0b54502688401097d8cb36da3f9ba75f894a39bccc65e5ae7bffb1256f03e", [:mix], [{:meck, "~> 0.8.4", [hex: :meck, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "inflex": {:hex, :inflex, "1.8.0", "7cfc752ae244b30b42ac9cf4c092771b485bc3424139aba4a933e54be8c63931", [:mix], []},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/spec/conqueuer/pool_spec.exs
+++ b/spec/conqueuer/pool_spec.exs
@@ -8,7 +8,7 @@ defmodule ConqueuerSpec.Pool do
 
   it "should allow a worker check out" do
     :poolboy.transaction :something_workers, fn worker ->
-      expect( is_pid( worker )).to be_true
+      expect( is_pid( worker )).to be_true()
     end
   end
 

--- a/spec/conqueuer/queue_spec.exs
+++ b/spec/conqueuer/queue_spec.exs
@@ -19,7 +19,7 @@ defmodule ConqueuerSpec.Queue do
     use ESpec, shared: true
 
     it "should not agree the item is a member" do
-      expect( Queue.member?( shared.queue, shared.item )).to be_false
+      expect( Queue.member?( shared.queue, shared.item )).to be_false()
     end
 
     it "should have a size of 0" do
@@ -45,7 +45,7 @@ defmodule ConqueuerSpec.Queue do
     end
 
     it "should agree the item is a member" do
-      expect( Queue.member?( shared.queue, shared.item )).to be_true
+      expect( Queue.member?( shared.queue, shared.item )).to be_true()
     end
 
     it "should have a size of 1" do
@@ -91,7 +91,7 @@ defmodule ConqueuerSpec.Queue do
     end
 
     it "should respond to limit_reached? with false" do
-      expect( Queue.limit_reached?( shared.limited_queue )).to be_false
+      expect( Queue.limit_reached?( shared.limited_queue )).to be_false()
     end
 
     describe "when limiting queue size is at or over the limit" do
@@ -108,7 +108,7 @@ defmodule ConqueuerSpec.Queue do
       end
 
       it "should respond to limit_reached? with true" do
-        expect( Queue.limit_reached?( shared.limited_queue )).to be_true
+        expect( Queue.limit_reached?( shared.limited_queue )).to be_true()
       end
 
       it "should prevent subsequent items from being queued and respond with `:limit_reached`" do

--- a/spec/conqueuer/queue_spec.exs
+++ b/spec/conqueuer/queue_spec.exs
@@ -52,6 +52,14 @@ defmodule ConqueuerSpec.Queue do
       expect( Queue.size( shared.queue )).to eq( 1 )
     end
 
+    it "should have a limit of `:unlimited`" do
+      expect( Queue.limit( shared.queue )).to eq( :unlimited )
+    end
+
+    it "should respond to limit_reached? with false" do
+      expect( Queue.limit_reached?( shared.queue )).to eq( false )
+    end
+
     it "should provide the item next" do
       {:ok, next_item} = Queue.next( shared.queue )
       expect( next_item ).to eq( shared.item )

--- a/spec/spec_helper.exs
+++ b/spec/spec_helper.exs
@@ -5,13 +5,3 @@ ESpec.start
 Enum.each files, fn(file) ->
   Code.require_file "support/#{file}", __DIR__
 end
-
-ESpec.configure fn(config) ->
-	config.before fn ->
-		# {:ok, hello: :world}
-	end
-
-	config.finally fn(shared) ->
-
-	end
-end

--- a/spec/support/helpers.ex
+++ b/spec/support/helpers.ex
@@ -1,7 +1,7 @@
 defmodule ConqueuerSpec.Helpers do
 
   def start_queue_app do
-    start_pool
+    start_pool()
   end
 
   def start_queue do

--- a/spec/support/helpers.ex
+++ b/spec/support/helpers.ex
@@ -10,6 +10,12 @@ defmodule ConqueuerSpec.Helpers do
     name
   end
 
+  def start_queue_with_limit(limit \\ 1) do
+    name = :WorkersQueueWithLimit
+    Conqueuer.Queue.start_link [limit: limit], [name: name]
+    name
+  end
+
   def start_pool do
     ConqueuerSpec.SomethingWorkerPool.start_link
   end


### PR DESCRIPTION
Adds an optional `limit` argument for `Conqueuer.Queue` to allow you to specify a rigid queue limit and prevent additional items from being added until it burns down. I've been using this in a production environment and its worked out well.

Totally understand if you don't want to add this, but figured I'd toss it your way anyhow.

----

Example:

```
worker(Conqueuer.Queue, [[limit: 100], [name: :SomeQueue]], id: :some_queue)
```

If the limit argument is provided and the queue is at its limit, calling
`Conqueuer.work(:some_pool, some_args)` will return `:limit_reached` - otherwise it will return `:ok` like usual.

Also added a couple helper functions:
* `Conqueuer.Queue.limit_reached?( :some_queue )` - returns `true` or `false`
* `Conqueuer.Queue.limit( :some_queue )` - returns integer limit size or `:unlimited`

I also updated the specs with these new features and added docs.