### PR TITLE
Add application dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Conqueuer.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :inflex, :poolboy]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
# Why?
Without listing the actual app dependencies in `application/0`, building/deploying releases with tools like exrm/distillery will not include these apps, and any application that depends on Conqueuer will fail to start.